### PR TITLE
Fixed Parser to work with new Litematica Material List Files

### DIFF
--- a/materiallistExcel/Program.cs
+++ b/materiallistExcel/Program.cs
@@ -99,7 +99,13 @@ namespace materiallistExcel
 
             Console.WriteLine("Removing all spaces and lines:");
 
-            FileContent = FileContent.Remove(FileContent.Length - 262);
+            int iChar = 0;
+            while (FileContent[iChar] != '|')
+            {
+                iChar++;
+            }
+
+            FileContent = FileContent.Remove(FileContent.Length - iChar * 3);
 
             var builder = new StringBuilder();
 

--- a/materiallistExcel/Program.cs
+++ b/materiallistExcel/Program.cs
@@ -105,7 +105,11 @@ namespace materiallistExcel
                 iChar++;
             }
 
-            FileContent = FileContent.Remove(FileContent.Length - iChar * 3);
+            FileContent = FileContent.Remove(FileContent.Length - (iChar * 3 + 2));
+
+            Console.WriteLine("Converting Line Endings");
+
+            FileContent = FileContent.Replace("\r\n", "\n");
 
             var builder = new StringBuilder();
 
@@ -137,11 +141,6 @@ namespace materiallistExcel
             {
 
                 string[] splitLine = line.Split('|');
-
-                if (splitLine.Length != 6)
-                {
-                    break;
-                }
 
                 /*
                 Item = splitLine[1]

--- a/materiallistExcel/Program.cs
+++ b/materiallistExcel/Program.cs
@@ -120,7 +120,7 @@ namespace materiallistExcel
             }
 
 
-            builder.Remove(0, builder.ToString().LastIndexOf('+') + 3);
+            builder.Remove(0, builder.ToString().LastIndexOf('+') + 2);
 
             FileContent = builder.ToString();
 

--- a/materiallistExcel/Program.cs
+++ b/materiallistExcel/Program.cs
@@ -138,6 +138,11 @@ namespace materiallistExcel
 
                 string[] splitLine = line.Split('|');
 
+                if (splitLine.Length != 6)
+                {
+                    break;
+                }
+
                 /*
                 Item = splitLine[1]
                 Total = splitLine[2]


### PR DESCRIPTION
The new files have a variable length(that is the same for every line) based on the length of the longest item names or the name of the material list.

These 3 commits make sure that the first and last lines are correctly removed.
Additionally I added a condition for the loop to stop before it crashes the parser if the next line is empty/not a full row